### PR TITLE
Adds crop as a query parameter to the fd2_plant_assets API endpoint

### DIFF
--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -230,6 +230,7 @@ export default {
           const results = await farmosUtil.getPlantAssets(
             this.location,
             [],
+            null,
             this.isInTrays,
             this.isInGround
           );

--- a/docs/contributing/views.md
+++ b/docs/contributing/views.md
@@ -17,7 +17,8 @@ The purpose of this document is to describe how to create custom API endpoints i
     - Use a path of `/api/fd2_[endpoint]`
 - Configure the View
 
-  - Format: JSON
+  - Format: Serializer
+    - Settings: JSON
   - Show: Fields
 
 - Use `farmos/api/fd2_[endpoint]` to test the new endpoint.
@@ -26,7 +27,8 @@ The purpose of this document is to describe how to create custom API endpoints i
 
 ### Installing the View
 
-- Export the view in farmOS.
+- Export the view in farmOS
+  - Administration -> Configuration -> Development -> Configuration synchronization
 - Copy into a `.yml` file in `farm_fd2/module/config/optional`
 - Remove the `uuid` line
 - `npm run build:fd2`

--- a/library/farmosUtil/farmosUtil.plant.js
+++ b/library/farmosUtil/farmosUtil.plant.js
@@ -79,7 +79,7 @@ export async function getPlantAsset(plantAssetId) {
 }
 
 /**
- * Get plant assets by location, beds and whether they
+ * Get plant assets by crop, location, beds and whether they
  * are in trays or in the ground.
  *
  * This function returns an array of objects with the following content:
@@ -91,11 +91,15 @@ export async function getPlantAsset(plantAssetId) {
  *  timestamp: <date of event (log) that created the plant asset>,
  *  location: <location of the plant asset>,
  *  beds: <array of bed name(s) (within location) where plant asset is located>,
+ *  inventory: <the number of units in inventory>.
+ *  units: <the name of the units for the inventory as a string>.
+ *  measure: <the measure of the unit as a string>.
  * }
  * ```
  *
- * @param {string} locationName the location of the plant assets.
+ * @param {string} [locationName=null] the location of the plant assets.
  * @param {string[]} [checkedBeds=[]] the beds of the plant assets.
+ * @param {string} [cropName=null] the name of the crop for the plant assets.
  * @param {boolean} [isInGround=true] include plants that are in the ground (direct seeded or transplanted).
  * @param {boolean} [isInTrays=true] include plants that are in trays (tray seeded but not transplanted).
  * @return {Object[]} array of objects with information about the matching plant assets.
@@ -104,8 +108,9 @@ export async function getPlantAsset(plantAssetId) {
  * @category Plant
  */
 export async function getPlantAssets(
-  locationName,
+  locationName = null,
   checkedBeds = [],
+  cropName = null,
   isInTrays = true,
   isInGround = true
 ) {
@@ -114,10 +119,24 @@ export async function getPlantAssets(
   }
 
   const farm = await getFarmOSInstance();
+  let paramStr = '';
 
-  let paramStr = '?location=' + locationName;
+  if (locationName) {
+    paramStr = 'location=' + locationName;
+  }
+
   if (checkedBeds.length > 0) {
-    paramStr = paramStr + '&beds=' + checkedBeds.join(',');
+    if (paramStr.length > 0) {
+      paramStr = paramStr + '&';
+    }
+    paramStr = paramStr + 'beds=' + checkedBeds.join(',');
+  }
+
+  if (cropName) {
+    if (paramStr.length > 0) {
+      paramStr = paramStr + '&';
+    }
+    paramStr = paramStr + 'crop=' + cropName;
   }
 
   let logCategories = [];
@@ -130,11 +149,18 @@ export async function getPlantAssets(
     logCategories.push('transplanting');
   }
   if (logCategories.length > 0) {
-    paramStr = paramStr + '&log-categories=' + logCategories.join(',');
+    if (paramStr.length > 0) {
+      paramStr = paramStr + '&';
+    }
+    paramStr = paramStr + 'log-categories=' + logCategories.join(',');
   }
 
-  const url = '/api/fd2_plant_assets' + paramStr;
-  const results = await farm.remote.request(url); // If no matches, then data will be an array in the response.
+  let url = '/api/fd2_plant_assets';
+  if (paramStr.length > 0) {
+    url = url + '?' + paramStr;
+  }
+
+  const results = await farm.remote.request(url);
 
   if (Array.isArray(results.data)) {
     for (const result of results.data) {
@@ -144,6 +170,12 @@ export async function getPlantAssets(
         result.beds = [];
       } else {
         result.beds = result.beds.split(',');
+      }
+      if (result.inventory) {
+        const inventorySplit = result.inventory.split(' ');
+        result.inventory = parseInt(inventorySplit[0]);
+        result.units = inventorySplit[1];
+        result.measure = inventorySplit[2].slice(1, -1);
       }
     }
     return results.data;

--- a/library/farmosUtil/farmosUtil.plant.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.plant.unit.cy.js
@@ -191,12 +191,8 @@ describe('Test the plant asset functions', () => {
     });
   });
 
-  // it('Check crops are split into array', () => {
-  // Currently sample DB has no cover crops.
-  // });
-
   it('Check beds are split into array', () => {
-    cy.wrap(farmosUtil.getPlantAssets('ALF', [], false, true)).then(
+    cy.wrap(farmosUtil.getPlantAssets('ALF', [], null, false, true)).then(
       (plantAssets) => {
         expect(plantAssets).to.have.length(2);
         expect(plantAssets[0].beds).to.have.length(1);
@@ -204,6 +200,18 @@ describe('Test the plant asset functions', () => {
         expect(plantAssets[1].beds).to.have.length(2);
         expect(plantAssets[1].beds[0]).to.equal('ALF-1');
         expect(plantAssets[1].beds[1]).to.equal('ALF-2');
+      }
+    );
+  });
+
+  it('Check fetching plants for a specific crop', () => {
+    cy.wrap(farmosUtil.getPlantAssets(null, [], 'RADISH')).then(
+      (plantAssets) => {
+        expect(plantAssets).to.have.length(6);
+
+        plantAssets.forEach((plantAsset) => {
+          expect(plantAsset.crop[0]).to.equal('RADISH');
+        });
       }
     );
   });
@@ -220,6 +228,16 @@ describe('Test the plant asset functions', () => {
         });
       });
     });
+  });
+
+  it('Check that inventory is processed', () => {
+    cy.wrap(farmosUtil.getPlantAssets(null, [], 'RADISH')).then(
+      (plantAssets) => {
+        expect(plantAssets[0].inventory).to.equal(105);
+        expect(plantAssets[0].units).to.equal('FEET');
+        expect(plantAssets[0].measure).to.equal('Length/depth');
+      }
+    );
   });
 
   it('Get plant assets for a specific field and bed', () => {
@@ -240,7 +258,7 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Get plant assets in trays only', () => {
-    cy.wrap(farmosUtil.getPlantAssets('CHUAU', [], true, false)).then(
+    cy.wrap(farmosUtil.getPlantAssets('CHUAU', [], null, true, false)).then(
       (plantAssets) => {
         expect(plantAssets).to.have.length(12);
         plantAssets.forEach((plantAsset) => {
@@ -256,7 +274,7 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Get plant assets in ground only', () => {
-    cy.wrap(farmosUtil.getPlantAssets('CHUAU', [], false, true)).then(
+    cy.wrap(farmosUtil.getPlantAssets('CHUAU', [], null, false, true)).then(
       (plantAssets) => {
         expect(plantAssets).to.have.length(6);
         plantAssets.forEach((plantAsset) => {
@@ -274,11 +292,11 @@ describe('Test the plant asset functions', () => {
   it('Get plant assets with both inTrays and inGround set to false', () => {
     const locationName = 'CHUAU';
 
-    cy.wrap(farmosUtil.getPlantAssets(locationName, [], false, false)).then(
-      (plantAssetIds) => {
-        expect(plantAssetIds).to.be.an('array').that.is.empty;
-      }
-    );
+    cy.wrap(
+      farmosUtil.getPlantAssets(locationName, [], null, false, false)
+    ).then((plantAssetIds) => {
+      expect(plantAssetIds).to.be.an('array').that.is.empty;
+    });
   });
 
   it('Get plant assets with no matching field asset', () => {

--- a/modules/farm_fd2/src/module/config/optional/views.view.farm_plant_assets.yml
+++ b/modules/farm_fd2/src/module/config/optional/views.view.farm_plant_assets.yml
@@ -4,12 +4,14 @@ dependencies:
   config:
     - asset.type.plant
     - taxonomy.vocabulary.log_category
+    - taxonomy.vocabulary.plant_type
   content:
-    - 'taxonomy_term:log_category:a62d8a24-2b27-4feb-b7af-618e404ecce2'
-    - 'taxonomy_term:log_category:c228aeef-1c9e-4a07-8807-45bcabf68dca'
-    - 'taxonomy_term:log_category:c7c71883-8c6f-4c98-9df7-abdb31c62076'
+    - 'taxonomy_term:log_category:4b408de0-6884-45ac-95b9-996d30bb7eaa'
+    - 'taxonomy_term:log_category:5c1ba889-6033-4fbe-a61b-66c7146afab6'
+    - 'taxonomy_term:log_category:a9a9809e-d53b-4005-9c8a-93ce0decebb3'
   module:
     - asset
+    - farm_inventory
     - farm_location
     - log
     - rest
@@ -18,11 +20,11 @@ dependencies:
     - taxonomy
     - user
 _core:
-  default_config_hash: ZLJTUMKzzAV51lvJzNbOixKVkihmKkTlTAPKU-WzjmM
+  default_config_hash: Tf_1spfzahQFl4-r3wnQb1uXKYo6lUnlNoeA_8nhj5s
 id: farm_plant_assets
 label: 'Farm Plant Assets'
 module: views
-description: 'Get plant assets currently in a location.'
+description: 'Get plant assets using a variety of query parameters.'
 tag: ''
 base_table: asset_field_data
 base_field: id
@@ -33,7 +35,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Farm Plant Assets by Location'
+      title: 'Farm Plant Assets'
       fields:
         uuid:
           id: uuid
@@ -435,6 +437,69 @@ display:
           multi_type: separator
           separator: ','
           field_api_classes: false
+        inventory:
+          id: inventory
+          table: asset
+          field: inventory
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: asset
+          plugin_id: asset_inventory
+          label: inventory
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: inventory
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: false
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: mini
         options:
@@ -814,6 +879,57 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        plant_type_target_id:
+          id: plant_type_target_id
+          table: asset__plant_type
+          field: plant_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: asset
+          entity_field: plant_type
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: plant_type_target_id_op
+            label: Crop
+            description: ''
+            use_operator: false
+            operator: plant_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: crop
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: true
+          vid: plant_type
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: false
       filter_groups:
         operator: AND
         groups:
@@ -863,7 +979,7 @@ display:
       tags: {  }
   fd2_plant_assets:
     id: fd2_plant_assets
-    display_title: 'Farm Plant Assets by Location'
+    display_title: 'Farm Plant Assets'
     display_plugin: rest_export
     position: 1
     display_options:
@@ -895,7 +1011,7 @@ display:
             plant_type_target_id:
               alias: crop
               raw_output: false
-      display_description: ''
+      display_description: 'Get plant assets using a variety of query parameters.'
       display_extenders:
         collapsible_filter:
           collapsible: false


### PR DESCRIPTION
**Pull Request Description**

Adds crop as a query parameter to the fd2_plant_asset api so that it is possible to query for all of the plants of a particular type of crop.  The getPlantAssets function in the farmOSUtil library is also updated to allow fetching all plants of a given crop.  All ripple effects of this change have also been patched.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
