### PR TITLE
adds harvest log category and associated patches

### DIFF
--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,2 +1,2 @@
-v3.7.0
+v3.7.1
 db.sample.tar.gz

--- a/bin/reinstallFD2Module.bash
+++ b/bin/reinstallFD2Module.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "Deleting custom fd2_fields..."
+docker exec fd2_farmos_school drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_unit_conversions')->delete();"
+docker exec fd2_farmos_school drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_harvest_unit')->delete();"
+echo "Deleted."
+echo "Running cron..."
+docker exec fd2_farmos_school drush cron > /dev/null 2>&1
+echo "Done."
+
+echo "Uninstalling farm_fd2 module..."
+docker exec fd2_farmos_school drush pmu farm_fd2 -y
+echo "Uninstalled."
+
+echo "Rebuilding farm_fd2 module..."
+npm run build:fd2 > /dev/null
+echo "Rebuilt."
+
+echo "Reinstalling farm_fd2 module..."
+docker exec fd2_farmos_school drush en farm_fd2 -y
+echo "Reinstalled."

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -14,7 +14,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the log categories', () => {
     cy.wrap(farmosUtil.getLogCategories()).then((categories) => {
       expect(categories).to.not.be.null;
-      expect(categories.length).to.equal(12);
+      expect(categories.length).to.equal(13);
 
       expect(categories[0].attributes.name).to.equal('amendment');
       expect(categories[0].attributes.description.value).to.equal(
@@ -22,9 +22,9 @@ describe('Test the log categories utility functions', () => {
       );
       expect(categories[0].type).to.equal('taxonomy_term--log_category');
 
-      expect(categories[11].attributes.name).to.equal('weed_control');
+      expect(categories[11].attributes.name).to.equal('transplanting');
       expect(categories[11].attributes.description.value).to.equal(
-        'For logs related to weed control.'
+        'For logs representing transplantation of a plant.'
       );
       expect(categories[11].type).to.equal('taxonomy_term--log_category');
     });
@@ -60,7 +60,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the logCategoryToTerm map', () => {
     cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryMap) => {
       expect(categoryMap).to.not.be.null;
-      expect(categoryMap.size).to.equal(12);
+      expect(categoryMap.size).to.equal(13);
 
       expect(categoryMap.get('seeding_cover_crop')).to.not.be.null;
       expect(categoryMap.get('seeding_cover_crop').type).to.equal(
@@ -77,7 +77,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the logCategoryIdToAsset map', () => {
     cy.wrap(farmosUtil.getLogCategoryIdToTermMap()).then((categoryIdMap) => {
       expect(categoryIdMap).to.not.be.null;
-      expect(categoryIdMap.size).to.equal(12);
+      expect(categoryIdMap.size).to.equal(13);
 
       cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryNameMap) => {
         const coverId = categoryNameMap.get('seeding_cover_crop').id;

--- a/modules/farm_fd2/src/module/farm_fd2.install
+++ b/modules/farm_fd2/src/module/farm_fd2.install
@@ -27,6 +27,7 @@ function add_log_categories() {
     ['name' => 'tillage', 'parent' => '', 'description' => 'For logs representing soil disturbances.' ],
     ['name' => 'transplanting', 'parent' => '', 'description' => 'For logs representing transplantation of a plant.' ],
     ['name' => 'weed_control', 'parent' => '', 'description' => 'For logs related to weed control.' ],
+    ['name' => 'harvest', 'parent' => '', 'description' => 'For logs related to harvesting of a plant.' ],
   ];
 
   addTerms($vocab, $terms);


### PR DESCRIPTION
**Pull Request Description**

Adds a harvest log category to the log category taxonomy.  Patches the associated tests and updates to the version of the sample database that contains this log category.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
