### PR TITLE
sets log category in created harvest logs

### DIFF
--- a/library/farmosUtil/farmosUtil.harvest.js
+++ b/library/farmosUtil/farmosUtil.harvest.js
@@ -10,7 +10,7 @@ import {
 } from './farmosUtil.crops.js';
 import {
   getPlantingLocationObjects,
-  //getLogCategoryObjects,
+  getLogCategoryObjects,
   getQuantityObjects,
 } from './farmosUtil.utilities.js';
 
@@ -40,7 +40,7 @@ export async function createHarvestLog(
   ]);
 
   const quantitiesArray = getQuantityObjects([quantity]);
-  //const logCategoriesArray = await getLogCategoryObjects(['harvest']);
+  const logCategoriesArray = await getLogCategoryObjects(['harvest']);
 
   let logName = dayjs(harvestDate).format('YYYY-MM-DD');
   logName += '_ha_';
@@ -59,7 +59,7 @@ export async function createHarvestLog(
     relationships: {
       location: locationsArray,
       asset: [{ type: 'asset--plant', id: plantAsset.id }],
-      //category: logCategoriesArray,
+      category: logCategoriesArray,
       quantity: quantitiesArray,
     },
   };

--- a/library/farmosUtil/farmosUtil.harvest.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.harvest.unit.cy.js
@@ -4,32 +4,23 @@ describe('Test the harvest log functions', () => {
   let fieldMap = null;
   let bedMap = null;
   let unitMap = null;
+  let logCategoryMap = null;
 
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
 
-    // cy.wrap(farmosUtil.getFieldNameToAssetMap()).then((map) => {
-    //   fieldMap = map;
-    // });
-
-    // cy.wrap(farmosUtil.getBedNameToAssetMap()).then((map) => {
-    //   bedMap = map;
-    // });
-
-    // cy.wrap(farmosUtil.getUnitIdToTermMap()).then((map) => {
-    //   unitMap = map;
-    // });
-
     cy.wrap(farmosUtil.getFieldNameToAssetMap()).as('fieldMap');
     cy.wrap(farmosUtil.getBedNameToAssetMap()).as('bedMap');
     cy.wrap(farmosUtil.getUnitIdToTermMap()).as('unitMap');
+    cy.wrap(farmosUtil.getLogCategoryToTermMap()).as(`categoryMap`);
 
-    cy.getAll(['@fieldMap', '@bedMap', '@unitMap']).then(
-      ([fields, beds, units]) => {
+    cy.getAll(['@fieldMap', '@bedMap', '@unitMap', `@categoryMap`]).then(
+      ([fields, beds, units, categories]) => {
         fieldMap = fields;
         bedMap = beds;
         unitMap = units;
+        logCategoryMap = categories;
       }
     );
   });
@@ -69,10 +60,10 @@ describe('Test the harvest log functions', () => {
 
           expect(result.attributes.status).to.equal('done');
 
-          // expect(result.relationships.category.length).to.equal(1);
-          // expect(result.relationships.category[0].id).to.equal(
-          //   categoryMap.get('harvest').id
-          // );
+          expect(result.relationships.category.length).to.equal(1);
+          expect(result.relationships.category[0].id).to.equal(
+            logCategoryMap.get('harvest').id
+          );
 
           expect(result.relationships.location.length).to.equal(3);
           expect(result.relationships.location[0].id).to.equal(


### PR DESCRIPTION
**Pull Request Description**

Updates the `farmosUtil.harvest.js` library and associated tests so that `harvest` is included in the log categories of the created log.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
