### PR TITLE
patches container names in reinstallFD2Module.bash

### DIFF
--- a/bin/reinstallFD2Module.bash
+++ b/bin/reinstallFD2Module.bash
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 echo "Deleting custom fd2_fields..."
-docker exec fd2_farmos_school drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_unit_conversions')->delete();"
-docker exec fd2_farmos_school drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_harvest_unit')->delete();"
+docker exec fd2_farmos drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_unit_conversions')->delete();"
+docker exec fd2_farmos drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_harvest_unit')->delete();"
 echo "Deleted."
 echo "Running cron..."
-docker exec fd2_farmos_school drush cron > /dev/null 2>&1
+docker exec fd2_farmos drush cron > /dev/null 2>&1
 echo "Done."
 
 echo "Uninstalling farm_fd2 module..."
-docker exec fd2_farmos_school drush pmu farm_fd2 -y
+docker exec fd2_farmos drush pmu farm_fd2 -y
 echo "Uninstalled."
 
 echo "Rebuilding farm_fd2 module..."
@@ -17,5 +17,5 @@ npm run build:fd2 > /dev/null
 echo "Rebuilt."
 
 echo "Reinstalling farm_fd2 module..."
-docker exec fd2_farmos_school drush en farm_fd2 -y
+docker exec fd2_farmos drush en farm_fd2 -y
 echo "Reinstalled."


### PR DESCRIPTION
**Pull Request Description**

The reinstall script appended `_school` to the container names to avoid a name clash on my machine and these slipped into the original PR by mistake.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
