### PR TITLE
Typo fixes on homepage_template.md

### DIFF
--- a/.devcontainer/homepage_template.md
+++ b/.devcontainer/homepage_template.md
@@ -11,7 +11,7 @@
               CODESPACE_NAME and CACHE_KEY are replaced by homepage.bash
               The value of CACHE_KEY is set to the timestamp.
               This prevents the browser from using a cached version of the
-              page, whcih does not work when the codespace is restarted.
+              page, which does not work when the codespace is restarted.
             -->
             Click here to <a href="https://%CODESPACE_NAME%-6901.app.github.dev?autoconnect=true&resize=remote&key=%CACHE_KEY%" target="_blank">Open the Development Environment in a Browser Tab</a>.
             <br>

--- a/.devcontainer/homepage_template.md
+++ b/.devcontainer/homepage_template.md
@@ -1,6 +1,6 @@
 <center>
   <h1>The FarmData2 Development Environment</h1>
-  <h3>The Development Enviornment is Ready</h3>
+  <h3>The Development Environment is Ready</h3>
 </center>
 
 <table>
@@ -34,13 +34,13 @@
             <i>Notes:</i> 
             <ol>
                 <li>
-                    The browser based version of the Development Environment has the limitation that you cannot copy and paste direclty between the Development Environment and your machine. Using a VNC client on your machine as described in Note #2 removes this limitation.
+                    The browser based version of the Development Environment has the limitation that you cannot copy and paste directly between the Development Environment and your machine. Using a VNC client on your machine as described in Note #2 removes this limitation.
                 </li>
                 <li>
-                    Opening in VNC requires that both the <code>gh</code> command line interface and a VNC client be installed on your machine. You can find more information about each of these in the <a href="../docs/install/codespaces.md" target="_blank">installaion documentation</a>.
+                    Opening in VNC requires that both the <code>gh</code> command line interface and a VNC client be installed on your machine. You can find more information about each of these in the <a href="../docs/install/codespaces.md" target="_blank">installation documentation</a>.
                 </li>
                 <li>
-                    The <code>gh cs ports forward 5901:5902</code> command forwards port <code>5901</code> in the codespace to port <code>5902</code> on your local machine to enable VNC to connet. If port <code>5902</code> is in use on your machine you can change <code>5902</code> to any available port. Then use your VNC client to connect to the new port.
+                    The <code>gh cs ports forward 5901:5902</code> command forwards port <code>5901</code> in the codespace to port <code>5902</code> on your local machine to enable VNC to connect. If port <code>5902</code> is in use on your machine you can change <code>5902</code> to any available port. Then use your VNC client to connect to the new port.
                 </li>
             </ol>
         </td>


### PR DESCRIPTION
Fixes four typos on this page that have been bugging me for a while

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
