### PR TITLE
Codespace fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "mounts": [
     "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock"
   ],
-  //"privileged": true,
+  "privileged": true,
   //"onCreateCommand": ".devcontainer/setup.bash",
   "forwardPorts": [80, 5901, 6901, 8888],
   "portsAttributes": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,7 @@
   "mounts": [
     "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock"
   ],
-  "privileged": true,
-  //"onCreateCommand": ".devcontainer/setup.bash",
+  "onCreateCommand": ".devcontainer/setup.bash",
   "forwardPorts": [80, 5901, 6901, 8888],
   "portsAttributes": {
     "80": {
@@ -25,12 +24,11 @@
   },
   "customizations": {
     "vscode": {
-      //"extensions": ["sirmspencer.vscode-autohide"],
+      "extensions": ["sirmspencer.vscode-autohide"],
       "settings": {
         // Hide most of the VSCode UI via settings.
         // Here instead of .vscode/settings.json so that
         // they apply only in the dev container.
-        /*
         "workbench.startupEditor": "none",
         "workbench.activityBar.location": "hidden",
         "workbench.statusBar.visible": false,
@@ -49,7 +47,6 @@
         "terminal.integrated.hideOnStartup": "always",
         "github.codespaces.devcontainerChangedNotificationStyle": "none",
         "autoHide.hideOnOpen": true,
-        */
         "tasks": {
           "version": "2.0.0",
           "tasks": [
@@ -69,64 +66,45 @@
                 "runOn": "folderOpen"
               },
               "presentation": {
-                "reveal": "never"
+                "reveal": "always",
+                "panel": "shared"
               }
             },
             {
               "label": "Open Loading Page",
               "type": "shell",
-              "command": "code -r .devcontainer/fd2_loading.md",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "code -r .devcontainer/fd2_loading.md"
             },
             {
               "label": "Customize Welcome Page",
               "type": "shell",
-              "command": "./.devcontainer/homepage.bash",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "./.devcontainer/homepage.bash"
             },
             {
               "label": "Run fd2-up.bash Script",
               "type": "shell",
-              "command": "bin/fd2-up.bash",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "bin/fd2-up.bash"
             },
             {
               "label": "Open Welcome Page",
               "type": "shell",
-              "command": "code -r .devcontainer/fd2_welcome.md",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "code -r .devcontainer/fd2_welcome.md"
             },
             {
               "label": "Start Heartbeat Server",
               "type": "shell",
-              "command": ".devcontainer/startHeartbeat.bash",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": ".devcontainer/startHeartbeat.bash"
             },
             {
               "label": "Open Running Page",
               "type": "shell",
-              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
-              "presentation": {
-                "reveal": "never",
-                "panel": "new"
-              }
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md"
             },
             {
               "label": "Start Heartbeat Listener",
               "type": "shell",
               "command": "fuser -k 8888/tcp; ncat -lk 8888",
               "presentation": {
-                "reveal": "always",
                 "panel": "new"
               }
             }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,13 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:debian",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
   "mounts": [
     "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock"
   ],
-  "onCreateCommand": ".devcontainer/setup.bash",
+  //"privileged": true,
+  //"onCreateCommand": ".devcontainer/setup.bash",
   "forwardPorts": [80, 5901, 6901, 8888],
   "portsAttributes": {
     "80": {
@@ -24,11 +25,12 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": ["sirmspencer.vscode-autohide"],
+      //"extensions": ["sirmspencer.vscode-autohide"],
       "settings": {
         // Hide most of the VSCode UI via settings.
         // Here instead of .vscode/settings.json so that
         // they apply only in the dev container.
+        /*
         "workbench.startupEditor": "none",
         "workbench.activityBar.location": "hidden",
         "workbench.statusBar.visible": false,
@@ -47,6 +49,7 @@
         "terminal.integrated.hideOnStartup": "always",
         "github.codespaces.devcontainerChangedNotificationStyle": "none",
         "autoHide.hideOnOpen": true,
+        */
         "tasks": {
           "version": "2.0.0",
           "tasks": [


### PR DESCRIPTION
### Purpose

GitHub codespaces appears to have changed a security setting requiring that terminals be visible when running a VSCode task. This PR changes the tasks in `.devcontainer` so that they run in a visible terminal.  This is less the aesthetic from the UI perspective but it does work as a patch for now,  

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
