### PR TITLE
Resets Data After Crop Is Changed

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -76,6 +76,7 @@ Steiman
 timonwong
 toplevel
 transplantings
+unharvestable
 unplugin
 unstaged
 usermod

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -24,6 +24,7 @@
       v-bind:required="true"
       v-bind:showValidityStyling="true"
       v-model:selected="crop"
+      v-on:click="resetForm(false)"
       v-on:error="(msg) => showErrorToast('Network Error', msg)"
     />
 
@@ -111,7 +112,7 @@
       v-bind:enableSubmit="formValid"
       v-bind:enableReset="true"
       v-on:submit="submitForm"
-      v-on:reset="resetForm"
+      v-on:reset="resetForm(true)"
     />
 
     <hr />
@@ -163,9 +164,11 @@ export default {
     },
   },
   methods: {
-    resetForm() {
-      this.date = '2019-06-15';
-      this.crop = null;
+    resetForm(formReset) {
+      if (formReset == true) {
+        this.date = '2019-06-15';
+        this.crop = null;
+      }
       this.pickedPlant = null;
       this.quantity = 1;
       this.unit = null;

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/fixtures/example.json
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/commands.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/e2e.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/e2e.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,74 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+
+  it('Checking whether the submit disappears after switching from a harvestable plant to an unharvestable plant', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+
+    cy.get('[data-cy="harvest-table"]').find('[type="radio"]').first().check();
+    cy.get('[data-cy="harvest-units"]').select('BUNCH');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('PEPPERS');
+
+    cy.get('[data-cy="harvest-no-plants-message"]')
+      .should('be.visible')
+      .should(
+        'contain.text',
+        'There are no PEPPERS plants available for harvest.'
+      );
+
+    cy.get('[data-cy="harvest-table"]').should('not.exist');
+    cy.get('[data-cy="harvest-quantity"]').should('not.exist');
+    cy.get('[data-cy="harvest-units"]').should('not.exist');
+    cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
+    cy.get('[data-cy="harvest-comment"]').should('not.exist');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+  });
+
+  it('Consistency in submit button and data save fix', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+
+    cy.get('[data-cy="harvest-table"]').find('[type="radio"]').first().check();
+    cy.get('[data-cy="harvest-units"]').select('BUNCH');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('CARROT');
+
+    cy.get('[data-cy="harvest-no-plants-message"]')
+      .should('be.visible')
+      .should(
+        'contain.text',
+        'There are no CARROT plants available for harvest.'
+      );
+
+    cy.get('[data-cy="harvest-table"]').should('not.exist');
+    cy.get('[data-cy="harvest-quantity"]').should('not.exist');
+    cy.get('[data-cy="harvest-units"]').should('not.exist');
+    cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
+    cy.get('[data-cy="harvest-comment"]').should('not.exist');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+  });
 });


### PR DESCRIPTION
### Purpose
I've fixed the issue described in #261, so that when a new crop is selected, data objects dependent on the crop selection are reset. This includes everything except the crop selected and the date.

### Verification steps
Situation 1
1.  Log on to FarmOS as manager1 and navigate to the OSS page of the FD2 section.
2.  In the crop dropdown, select a plant with harvestable crops (ie Bell Pepper).
3. Populate the form with information (select Quantity and Units) and do not submit. Notice that the submit button becomes enabled.
4. Switch to a plant with no harvestable crops (ie Pepper).
5. Notice that the submit button is now disabled.

Situation 2
1.  Log on to FarmOS as manager1 and navigate to the OSS page of the FD2 section.
2.  In the crop dropdown, select a plant with harvestable crops (ie Bell Pepper).
3. Populate the form with information (select Quantity and Units) and do not submit. Notice that the submit button becomes enabled.
4. Switch to a plant with no harvestable crops that was functioning before issue was fixed (ie Carrot).
5. Notice that the submit button is now disabled.

Situation 3
1.  Log on to FarmOS as manager1 and navigate to the OSS page of the FD2 section.
2.  In the crop dropdown, select a plant with multiple harvestable crops (ie Radish).
3. Populate the form with information, making sure to select a crop below spot 3, and do not submit. Notice that the submit button becomes enabled.
4. Switch to a plant with only one harvestable crop (ie Arugula).
5. Notice that the submit button is now disabled.


### Approach
I added an extra if-statement on line 168, which checks whether the reset function is being called on the whole form or not. Nested inside the if-statement was the reset call for the crop and date. I also added a variable to the resetForm function, which stated whether the function call was coming from the reset button or because a new crop was picked.

### Testing
I added two tests. One walks through the scenario described in #261 and verifies that it is fixed. The other checks Carrot, where this issue could not be replicated, to make sure consistency is maintained in results. I did not test the situation where the form was submittable when switching to a crop with one option, from a crop with multiple options. This was because my fix works in such a way that if it fixes the scenario in #261 it will work for the issue described in the prior sentence.

### Related issues
Closes #261 

### Additional information
This took me around 2 hours, in which an hour of that was me using the wrong cypress terminal command (the one from Tutorial 10 instead of Application 10). This explains the extra files you see changed, and was one of the more embarrassing things I have done in this class. 

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
