### PR TITLE
Add the Harvest entry point to FarmData2 menu

### DIFF
--- a/modules/farm_fd2/src/entrypoints/harvest/App.vue
+++ b/modules/farm_fd2/src/entrypoints/harvest/App.vue
@@ -1,0 +1,256 @@
+<template>
+  <div
+    id="OSS1"
+    data-cy="OSS1"
+  >
+    <div
+      id="harvest-header"
+      data-cy="harvest-header"
+    >
+      <h1>Harvest</h1>
+    </div>
+
+    <DateSelector
+      id="harvest-date"
+      data-cy="harvest-date"
+      v-bind:required="true"
+      v-bind:showValidityStyling="true"
+      v-model:date="date"
+    />
+
+    <CropSelector
+      id="harvest-crop"
+      data-cy="harvest-crop"
+      v-bind:required="true"
+      v-bind:showValidityStyling="true"
+      v-model:selected="crop"
+      v-on:error="(msg) => showErrorToast('Network Error', msg)"
+    />
+
+    <hr />
+
+    <div
+      id="harvest-table-quantity-unit"
+      v-if="plantList.length > 0"
+    >
+      <table
+        id="harvest-table"
+        data-cy="harvest-table"
+      >
+        <tr id="harvest-table-header">
+          <th></th>
+          <th>Location</th>
+          <th>Bed</th>
+          <th>Planted Date</th>
+        </tr>
+        <tr
+          v-for="plant in sortedPlantList"
+          v-bind:key="plant.id"
+        >
+          <td>
+            <input
+              type="radio"
+              name="harvest-plant"
+              v-bind:value="plant"
+              v-model="pickedPlant"
+            />
+          </td>
+          <td>{{ plant.location }}</td>
+          <td>{{ plant.beds.join(', ') }}</td>
+          <td>{{ plant.timestamp }}</td>
+        </tr>
+      </table>
+
+      <NumericInput
+        id="harvest-quantity"
+        data-cy="harvest-quantity"
+        label="Quantity"
+        v-bind:required="true"
+        v-bind:incDecValues="[1, 5]"
+        v-bind:minValue="1"
+        v-model:value="quantity"
+      />
+      <select
+        id="harvest-units"
+        data-cy="harvest-units"
+        v-model="unit"
+        v-if="this.unitList.length > 1"
+      >
+        <option
+          v-for="unit in unitList"
+          v-bind:key="unit.id"
+          v-bind:value="unit"
+        >
+          {{ unit.attributes.name }}
+        </option>
+      </select>
+      <span
+        data-cy="single-harvest-unit"
+        v-if="this.unitList.length === 1"
+        >{{ unit.attributes.name }}</span
+      >
+      <hr />
+
+      <CommentBox
+        id="harvest-comment"
+        data-cy="harvest-comment"
+        v-model:comment="comment"
+      />
+    </div>
+    <div
+      id="harvest-no-plants-message"
+      data-cy="harvest-no-plants-message"
+      v-if="plantList.length === 0 && crop"
+    >
+      There are no {{ crop }} plants available for harvest.
+    </div>
+
+    <SubmitResetButtons
+      id="harvest-submit-reset"
+      data-cy="harvest-submit-reset"
+      v-bind:enableSubmit="formValid"
+      v-bind:enableReset="true"
+      v-on:submit="submitForm"
+      v-on:reset="resetForm"
+    />
+
+    <hr />
+  </div>
+</template>
+
+<script>
+import DateSelector from '@comps/DateSelector/DateSelector.vue';
+import CropSelector from '@comps/CropSelector/CropSelector.vue';
+import NumericInput from '@comps/NumericInput/NumericInput.vue';
+import CommentBox from '@comps/CommentBox/CommentBox.vue';
+import SubmitResetButtons from '@comps/SubmitResetButtons/SubmitResetButtons.vue';
+
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
+export default {
+  components: {
+    DateSelector,
+    CropSelector,
+    NumericInput,
+    CommentBox,
+    SubmitResetButtons,
+  },
+  data() {
+    return {
+      date: '2019-06-15',
+      crop: null,
+      pickedPlant: null,
+      quantity: 1,
+      unit: null,
+      comment: '',
+      plantList: [],
+      unitList: [],
+    };
+  },
+  computed: {
+    formValid() {
+      return (
+        this.date != '' &&
+        this.crop != null &&
+        this.pickedPlant != null &&
+        this.quantity > 0 &&
+        this.unit != null
+      );
+    },
+    sortedPlantList() {
+      return [...this.plantList].sort(
+        (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+      );
+    },
+  },
+  methods: {
+    resetForm() {
+      this.date = '2019-06-15';
+      this.crop = null;
+      this.pickedPlant = null;
+      this.quantity = 1;
+      this.unit = null;
+      this.comment = '';
+    },
+    async submitForm() {
+      let measure = '';
+      if (this.unit.relationships.parent.length > 0) {
+        const unitMap = await farmosUtil.getUnitIdToTermMap();
+        const measureObj = unitMap.get(this.unit.relationships.parent[0].id);
+        measure = measureObj.attributes.name;
+      }
+
+      const quantity = await farmosUtil.createStandardQuantity(
+        measure,
+        this.quantity,
+        'harvest',
+        this.unit.attributes.name
+      );
+
+      const plantAsset = await farmosUtil.getPlantAsset(this.pickedPlant.uuid);
+
+      await farmosUtil.createHarvestLog(
+        this.date,
+        this.pickedPlant.location,
+        this.pickedPlant.beds,
+        plantAsset,
+        quantity,
+        this.comment
+      );
+    },
+  },
+  watch: {
+    async crop() {
+      if (this.crop) {
+        this.plantList = await farmosUtil.getPlantAssets(
+          null,
+          [],
+          this.crop,
+          false,
+          true
+        );
+
+        const units = await farmosUtil.getHarvestUnits(this.crop);
+        this.unitList = units;
+        if (this.unitList.length == 1) {
+          this.unit = this.unitList[0];
+        } else {
+          this.unit = null;
+        }
+      } else {
+        this.plantList = [];
+        this.unitList = [];
+      }
+    },
+  },
+};
+</script>
+
+<style>
+/* import some styling that applies to all FD2 entry points */
+@import url('@css/fd2-mobile.css');
+
+#harvest-header {
+  text-align: center;
+}
+
+#harvest-date,
+#harvest-comment {
+  margin-bottom: 10px;
+}
+
+.label-margin {
+  margin-right: 10px;
+}
+
+#harvest-table,
+#harvest-table-header {
+  border: 2px solid black;
+  width: auto;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+tr th {
+  font-weight: bold !important;
+}
+</style>

--- a/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
@@ -1,0 +1,80 @@
+describe('Tests for the Harvest form', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.login('manager1', 'farmdata2');
+    cy.visit('fd2_school/OSS1');
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Check initial state of the Harvest form', () => {
+    cy.get('[data-cy="harvest-header"]')
+      .should('be.visible')
+      .should('have.text', 'Harvest');
+    cy.get('[data-cy="harvest-date"]')
+      .find('[data-cy="date-input"]')
+      .should('be.visible')
+      .should('have.value', '2019-06-15');
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .should('be.visible')
+      .should('have.value', null);
+    cy.get('[data-cy="harvest-submit-reset"]').should('be.visible');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+
+    cy.get('[data-cy="harvest-table"]').should('not.exist');
+    cy.get('[data-cy="harvest-quantity"]').should(`not.exist`);
+    cy.get('[data-cy="harvest-units"]').should(`not.exist`);
+    cy.get('[data-cy="single-harvest-unit"]').should(`not.exist`);
+    cy.get('[data-cy="harvest-comment"]').should(`not.exist`);
+  });
+
+  it('Selecting crop with harvestable plants', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+
+    cy.get('[data-cy="harvest-table"]').should('be.visible');
+    cy.get('[data-cy="harvest-quantity"]')
+      .find('[data-cy="numeric-input"]')
+      .should('be.visible')
+      .should('have.value', '1');
+    cy.get('[data-cy="harvest-units"]')
+      .should('be.visible')
+      .should('have.value', null);
+    cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
+    cy.get('[data-cy="harvest-comment"]')
+      .find('[data-cy="comment-input"]')
+      .should('be.visible')
+      .should('have.value', '');
+  });
+
+  it('Selecting crop without harvestable plants', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('CARROT');
+
+    cy.get('[data-cy="harvest-no-plants-message"]')
+      .should('be.visible')
+      .should(
+        'contain.text',
+        'There are no CARROT plants available for harvest.'
+      );
+
+    cy.get('[data-cy="harvest-table"]').should('not.exist');
+    cy.get('[data-cy="harvest-quantity"]').should('not.exist');
+    cy.get('[data-cy="harvest-units"]').should('not.exist');
+    cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
+    cy.get('[data-cy="harvest-comment"]').should('not.exist');
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/harvest/harvest.html
+++ b/modules/farm_fd2/src/entrypoints/harvest/harvest.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Harvest</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/harvest/harvest.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/harvest/harvest.js
+++ b/modules/farm_fd2/src/entrypoints/harvest/harvest.js
@@ -1,0 +1,13 @@
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(createPinia());
+
+app.mount('#app');

--- a/modules/farm_fd2/src/entrypoints/harvest/index.html
+++ b/modules/farm_fd2/src/entrypoints/harvest/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Harvest</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/harvest/harvest.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -82,3 +82,14 @@ soil_disturbance:
   css:
     component:
       style/style.css: {}
+
+harvest:
+  js:
+    harvest/harvest.js:
+      preprocess: false
+      minified: true
+      attributes: { type: 'module' }
+  css:
+    component:
+      style/style.css: {}
+    

--- a/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
@@ -48,3 +48,9 @@ farm.fd2_soil_disturbance:
   parent: farm.fd2_soil
   route_name: farm.fd2_soil_disturbance.content
   weight: 100
+farm.fd2_harvest:
+  title: 'Harvest'
+  description: 'Data entry form for recording a harvest.'
+  parent: farm.fd2_main
+  route_name: farm.fd2_harvest.content
+  weight: 100

--- a/modules/farm_fd2/src/module/farm_fd2.routing.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.routing.yml
@@ -62,3 +62,10 @@ farm.fd2_soil_disturbance.content:
     _title: 'Soil Disturbance'
   requirements:
     _permission: 'access content,create standard quantity,create activity log'
+farm.fd2_harvest.content:
+  path: '/fd2/harvest'
+  defaults:
+    _controller: '\Drupal\farm_fd2\Controller\FD2_Controller::content'
+    _title: 'Harvest'
+  requirements:
+    _permission: 'access content,create standard quantity,create harvest log'


### PR DESCRIPTION
### Purpose

Adds the Harvest entrypoint to the FarmData2 menu for the project work.

### Verification steps

1. Rebuild the FarmData2 module.
2. Visit "FarmData2" -> "Harvest"
3. Confirm that the Harvest form is present and functional.

### Approach

Created a new entrypoint with `addEntrypoint.bash`, deleted unnecessary files and replaced `App.vue` with the `App.vue` from `OSS1` in FD2School.

### Testing

The tests from `OSS1` were moved here.

### Related issues

None.

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
