### PR TITLE
fix: reset harvest form and disable submit button on crop change

### DIFF
--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -200,6 +200,9 @@ export default {
   },
   watch: {
     async crop() {
+      this.pickedPlant = null;
+      this.quantity = 1;
+      this.unit = null;
       if (this.crop) {
         this.plantList = await farmosUtil.getPlantAssets(
           null,

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -78,13 +78,35 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
 
-  it('Switching from harvestable plant to non-harvestable plant', () => {
+  it('Check submit button and reset form when switching between plants', () => {
     cy.get('[data-cy="harvest-crop"]')
       .find('[data-cy="crop-selector"]')
       .find('[data-cy="selector-input"]')
       .select('ARUGULA');
 
     cy.get('[data-cy="harvest-table"]').find('[type=radio]').first().check();
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+
+    cy.get('[data-cy="harvest-quantity"] input').should('have.value', '1');
+    cy.get('[data-cy="harvest-table"] [type=radio]:checked').should(
+      'not.exist'
+    );
+    cy.get('[data-cy="harvest-units"]').should('have.value', null);
+
+    cy.get('[data-cy="harvest-table"]').find('[type=radio]').first().check();
+    cy.get('[data-cy="harvest-units"]').select('BUNCH');
+
     cy.get('[data-cy="harvest-submit-reset"]')
       .find('[data-cy="submit-button"]')
       .should('be.enabled');

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,37 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+
+  it('Switching from harvestable plant to non-harvestable plant', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+
+    cy.get('[data-cy="harvest-table"]').find('[type=radio]').first().check();
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ASPARAGUS');
+
+    cy.get('[data-cy="harvest-no-plants-message"]')
+      .should('be.visible')
+      .should(
+        'contain.text',
+        'There are no ASPARAGUS plants available for harvest.'
+      );
+
+    cy.get('[data-cy="harvest-table"]').should('not.exist');
+    cy.get('[data-cy="harvest-quantity"]').should('not.exist');
+    cy.get('[data-cy="harvest-units"]').should('not.exist');
+    cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
+    cy.get('[data-cy="harvest-comment"]').should('not.exist');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+  });
 });


### PR DESCRIPTION
### Purpose
This PR fixes a bug in the Harvest form where the Submit button remained enabled after switching from a valid crop selection to a different crop. The goal is to ensure that the form correctly resets whenever the crop selection changes.

### Verification steps
1. Log in to FarmOS and navigate to the OSS1 page.
2. Select a crop that has harvestable plants (e.g., Arugula or Radish).
3. Select a plant from the table, enter a valid quantity, and select a unit.
4. Confirm that the Submit button becomes enabled.
5. Change the crop selection to a different crop (harvestable or non-harvestable).
6. Verify that the Submit button becomes disabled.
7. Verify that the internal form data (Selected Plant, Quantity, Units) has reset.

### Approach
The issue was caused by the `pickedPlant`, `quantity`, and `unit` properties retaining their values when the crop selection changed. This led the `formValid` logic to evaluate as `true` using old data. These Vue data properties are now explicitly reset at the start of the `crop` watcher to ensure that the form becomes invalid and the Submit button disables upon changing the crop.

### Testing
I added a new test case `Check submit button and reset form when switching between plants`. This test starts with a valid Arugula form, then switches to Radish to ensure the Submit button disables and form data resets. It also verifies that populating the Radish form re-enables the button, and confirms that switching to a non-harvestable crop like Asparagus correctly hides all inputs and disables the Submit button.

### Related issues
- Closes #266 

### Additional information
This took me around 2 hours to complete

### Licensing Certification
FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.