### PR TITLE
Homework11 oss1

### DIFF
--- a/modules/farm_fd2_school/src/entrypoints/FD4_Application/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/FD4_Application/harvest.e2e.cy.js
@@ -11,8 +11,4 @@ describe('Tests for the Harvest form', () => {
     cy.saveLocalStorage();
     cy.saveSessionStorage();
   });
-
-  it('Placeholder test', () => {
-    cy.get('[data-cy="does-not-exist"]');
-  });
 });

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -200,6 +200,8 @@ export default {
   },
   watch: {
     async crop() {
+      this.pickedPlant = null;
+      this.unit = null;
       if (this.crop) {
         this.plantList = await farmosUtil.getPlantAssets(
           null,

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -91,6 +91,8 @@ describe('Tests for the Harvest form', () => {
       .first()
       .check();
 
+    cy.get('[data-cy="harvest-units"]').should('not.exist');
+
     cy.get('[data-cy="harvest-quantity"]')
       .find('[data-cy="numeric-input"]')
       .should('be.visible')

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,36 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+
+  it('disables submit button when changed to crop with no plants ', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+
+    cy.get('[data-cy="harvest-table"]').should('be.visible');
+
+    cy.get('[data-cy="harvest-table"]')
+      .find('input[type="radio"]')
+      .first()
+      .check();
+
+    cy.get('[data-cy="harvest-quantity"]')
+      .find('[data-cy="numeric-input"]')
+      .should('be.visible')
+      .should('have.value', '1');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ASPARAGUS');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.not.enabled');
+  });
 });

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -110,5 +110,7 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="harvest-submit-reset"]')
       .find('[data-cy="submit-button"]')
       .should('be.not.enabled');
+
+    //change to make push
   });
 });


### PR DESCRIPTION
### Purpose
This pull request fixes an issue in the Harvest form where the Submit Button remains enabled after the selected crop is changed to one with no harvestable plants. The change ensures that when the form transitions into an invalid state, the submit button is properly disabled to prevent invalid harvest submissions.

### Verification steps

1. login as `manager1`.
2. Navigate to **OSS1** under the **FD2** **School** sidebar menu.
3. Select crop with harvestable plants ('ARUGULA').
4. Select a plant from the table.
5. Select a harvest unit if applicable.
6. See that the **Submit** button in enabled.
7. Change the selected crop to one without harvestable plants ('ASPARAGUS').
8.  See that a message is displayed "There are not ASPARAGUS plants available for harvest." is displayed.
9. Confirm the **Submit** button is now disabled 

### Approach
The bug occured since previously whatever was selected for each option in the form was preserved even after changing the crop. When the user selected a new crop with no harvestable plants, `pickedPlant` and `unit` values from the previous crop were still set. This caused the computed property, `formValid` to continuously return `true`.

To correct this, the watcher `crop` now resets both `pickedPlant` and `unit` whenever the crop is changed. This makes sure that the form cannot be valid under any scenario unless a proper crop is chosen and the form is filled properly. The solution also only makes changes in an explicit area which maintains the original program design. 

### Testing
One test was added in Cypress to validate the behavior of the code change. The purpose is to verify that when a user fills in the Harvest form with a valid crop and then changes to a crop with no available plants, the Submit button becomes disabled. 
The test:

1. Picks ARUGULA 
2. Checks the harvest table is visible
3. Chooses a plant asset
4. Checks harvest units are not visible for this crop
5. Checks Quantity is visible 
6. Checks submit button is enabled 
7. Chooses ASPARAGUS 
8. Checks submit button is disabled 

Prior to the bug fix, this test failed pass over and over. 

### Related issues
Closes #263 

### Additional information
~3 hr spent in total.

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
