### PR TITLE
Fix Harvest Form: Disable submit when switching to crop with no plants

### DIFF
--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -200,6 +200,11 @@ export default {
   },
   watch: {
     async crop() {
+      this.pickedPlant = null;
+      this.quantity = 1;
+      this.unit = null;
+      this.comment = '';
+
       if (this.crop) {
         this.plantList = await farmosUtil.getPlantAssets(
           null,

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,30 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+  it('Disables submit when switching to a crop with no harvestable plants', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('BROCCOLI');
+
+    cy.get('[data-cy="harvest-table"]')
+      .find('input[type="radio"]')
+      .first()
+      .check();
+
+    cy.get('[data-cy="harvest-units"]').select(1);
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ASPARAGUS');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+  });
 });


### PR DESCRIPTION
### Purpose
This PR fixes a bug in the Harvest form where the Submit button remained enabled after switching from a crop with harvestable plants to a crop with no harvestable plants. The purpose of the PR is to ensure that the Submit button is only enabled when all required fields (date, crop, plant, quantity, and unit) are valid and that the form resets appropriately whenever the user selects a different crop.

### Verification steps
Follow these steps manually to confirm that the fix behaves correctly:
1. Open the Harvest form (FD2 School → OSS1).
2. Select a crop that has harvestable plants (e.g., BROCCOLI).
3. Select a plant from the table.
4. Select units.
5. Confirm that the Submit button is enabled.
6. Switch to a crop with no harvestable plants (e.g., ASPARAGUS).
7. Confirm that:
- The plant table disappears.
- Units reset.
- The Submit button becomes disabled.
If all steps above behave as described, the bug is fixed.

### Approach
The cause of the bug was that some state variables (pickedPlant, quantity, unit, comment) were not reset when the user changed the selected crop. As a result, formValid could continue to evaluate to true even though the new crop had no plant data associated with it.
This PR resolves the issue by resetting all crop-dependent fields whenever a new crop is selected. Specifically:
- The watch: { crop } block now clears pickedPlant, resets quantity to 1, clears unit, and clears comment before loading new plant and unit data.
- This ensures that formValid reevaluates based on the current crop and no stale data remains.
As a result, the Submit button correctly becomes disabled when selecting a crop with no harvestable plants.
### Testing
This PR adds an automated Cypress test:
Test: "Disables submit when switching to a crop with no harvestable plants"
Purpose:
- Verifies that the form becomes valid when a user selects a crop with harvestable plants, selects a plant, and selects units.
- Then checks that switching to a crop with no harvestable plants correctly resets form state and disables the Submit button.
- This test failed before the fix and now passes after the fix.
### Related issues
Closed #262 
### Additional information
Time spent: approximately 3 hours
### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
