### PR TITLE
Fix Submit button validation and form reset when changing crops in Harvest form

### DIFF
--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -44,7 +44,7 @@
           <th>Planted Date</th>
         </tr>
         <tr
-          v-for="plant in sortedPlantList"
+          v-for="(plant, index) in sortedPlantList"
           v-bind:key="plant.id"
         >
           <td>
@@ -53,6 +53,7 @@
               name="harvest-plant"
               v-bind:value="plant"
               v-model="pickedPlant"
+              v-bind:data-cy="`harvest-plant-${index}`"
             />
           </td>
           <td>{{ plant.location }}</td>
@@ -200,6 +201,9 @@ export default {
   },
   watch: {
     async crop() {
+      this.pickedPlant = null;
+      this.quantity = 1;
+      this.comment = '';
       if (this.crop) {
         this.plantList = await farmosUtil.getPlantAssets(
           null,

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/fixtures/example.json
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/commands.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/e2e.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/cypress/support/e2e.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,70 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+
+  it('Select crop, plants, quantity, unit, and then change to a crop with no harvestable plants', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+    cy.get('[data-cy="harvest-plant-0"]').click();
+    cy.get('[data-cy="harvest-quantity"]').type('1');
+    cy.get('[data-cy="harvest-units"]').select(0);
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.disabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('PEPPERS');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.disabled');
+  });
+
+  it('Select crop, plants, quantity, unit, and then change to a crop with fewer harvestable plants', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+    cy.get('[data-cy="harvest-plant-5"]').click();
+    cy.get('[data-cy="harvest-quantity"]').type('1');
+    cy.get('[data-cy="harvest-units"]').select(0);
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.disabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.disabled');
+  });
+
+  it('Form fields carry over after switching crops', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+
+    cy.get('[data-cy="harvest-plant-5"]').click();
+    cy.get('[data-cy="harvest-quantity"]').type('3');
+    cy.get('[data-cy="harvest-units"]').select(2);
+    cy.get('[data-cy="harvest-comment"]').type('Harvest test');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.disabled');
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+    cy.get('[data-cy="harvest-quantity"]').should('have.value', '');
+    cy.get('[data-cy="harvest-comment"]').should('have.value', '');
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.disabled');
+  });
 });


### PR DESCRIPTION
### Purpose

This PR fixes form-validation issues in the Harvest form that occur when switching between crops. Previously, when the user selected a crop with harvestable plants, filled all required fields, and enabled the Submit button, switching to another crop did not properly reset the form. This allowed the Submit button to remain enabled in invalid scenarios.

The purpose of this PR is to ensure that the Harvest form always resets when the selected crop changes, and that the Submit button is only enabled when all required conditions are satisfied.

### Verification steps

Log into farmOS as manager1.

Navigate to FD2 School → OSS1.

Select a crop with harvestable plants (e.g., RADISH).

Select one plant from the table, enter a valid Quantity and Unit, and enter a Comment.

Confirm the Submit button becomes enabled by hovering over it.

Change the crop selection to a crop without harvestable plants (e.g., HERB).

Verify the form resets; the plants table, quantity and units dropdown disappear; and the Submit button becomes disabled.

Change back to a crop with harvestable plants:

Verify no old quantity/comment data carries over.

Verify the Submit button stays disabled until a new plant and all the required values (quantity and units) are selected.

Try switching between crops with multiple vs single harvestable plants (e.g., RADISH → ARUGULA).

Verify the Submit button disables on crop change.

Verify no plant selection is pre-populated.

Verify previous input values do not persist.

### Approach

The main issue was that the form state was not being reset when the user changed crops. Because previously selected values (plant selection, quantity, unit, comments) were carried over to the new crop, the form remained in a state where the Submit button appeared valid even though it was no longer valid for the newly selected crop.

Changes implemented:

- When the crop selection changes:

  - The selected plant is cleared.
  
  - The Quantity and Comment fields are reset to default values.
  
  - Validation is re-run to ensure the Submit button updates correctly.

- Ensured the Submit button logic consistently uses current form state instead of any stale inputs from a previously selected crop.

This ensures that:

- Users cannot submit a harvest when no valid plant is selected.
- 
- Form fields never carry data across different crop selections.
- 
- The Submit button always reflects the **current** validity of the form.

### Testing

Cypress tests were added/updated to:

- Verify that the form resets when the crop is changed.
- Verify that the Submit button becomes disabled after switching to:
- A crop with no harvestable plants.
- A crop with one harvestable plant when no plant is selected.

Confirm that quantity and comment do not persist after switching crops.
### Related issues
Closes [Issue #259]

### Additional information
This work took around 3 hours. Everything else in the bug report looks fine. 

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
