### PR TITLE
H11

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -55,6 +55,7 @@ novnc
 PASA
 pgid
 pgrep
+Pham
 Picklist
 pietmichal
 Pietraszko

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Lam Pham
+
 # FarmData2
 
 Welcome to FarmData2. FarmData2 aims to support the day-to-day operation of diversified vegetable farms while facilitating the record keeping necessary for organic certification and for the study of sustainable farming practices. For example, FarmData2 forms enable farm workers to efficiently and reliably enter data about common operations at the time they occur:
@@ -56,7 +58,6 @@ FarmData2 is thankful to the following organizations for their in-kind and finan
 
 - [Dickinson College](https://www.dickinson.edu/)
 - [farmOS](https://farmos.org/)
-- [The GNOME Community Engagement Challenge](https://www.gnome.org/challenge/)
 - [The National Science Foundation (DUE-2013069)](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2013069)
 - [The Non-Profit FOSS Institute](https://npfi.org/)
 - [PASA Sustainable Agriculture](https://pasafarming.org/)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+Aaron Shin
 Lam Pham
 
 # FarmData2

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -216,6 +216,7 @@ export default {
         } else {
           this.unit = null;
         }
+        this.pickedPlant = null;
       } else {
         this.plantList = [];
         this.unitList = [];

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,31 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+
+  it('Disables submit when switching to a crop with no harvestable plants', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('BROCCOLI');
+
+    cy.get('[data-cy="harvest-table"]')
+      .find('input[type="radio"]')
+      .first()
+      .check();
+
+    cy.get('[data-cy="harvest-units"]').select(1);
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ASPARAGUS');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+  });
 });


### PR DESCRIPTION
# Purpose
This PR fixes a bug in the Harvest form where the **Submit** button remained enabled after switching from a crop with harvestable plants to a crop with no harvestable plants.  
The goal is to ensure the Submit button is enabled **only** when **all required fields** (date, crop, plant, quantity, and unit) are valid, and that the form fully resets whenever the user selects a different crop.

### Verification steps
1. Open the Harvest form (FD2 School → OSS1).  
2. Select a crop with harvestable plants (e.g., **BROCCOLI**).  
3. Select a plant from the table.  
4. Select units.  
   → Confirm the **Submit** button is **enabled**.  
5. Switch to a crop with no harvestable plants (e.g., **ASPARAGUS**).  
   → Confirm that:  
   - The plant table disappears  
   - The unit selection resets  
   - The **Submit** button becomes **disabled**  

If all steps behave as described, the bug is fixed.

### Approach
The bug occurred because the selected plant (pickedPlant) was not cleared when the user switched to a new crop. This caused stale data to remain, leaving formValid incorrectly true even if the new crop had no harvestable plants.

This PR resolves the issue by resetting pickedPlant immediately whenever the crop changes:

In the watch: { crop } block, we now:

Set pickedPlant = null at the start of the watcher.

Load the new plantList and unitList for the selected crop.

Reset unit if there is only one option; otherwise leave it null.

By clearing the previous plant selection before loading new data, formValid is correctly re-evaluated, ensuring the Submit button is disabled when no harvestable plants are available.

### Testing
Added a new Cypress end-to-end test in `harvest.e2e.cy.js`:

**Test name:** "Disables submit when switching to a crop with no harvestable plants"  
**What it verifies:**
- The form becomes valid after selecting a crop → plant → units
- Switching to a crop with no harvestable plants resets the form and disables the Submit button

This test failed before the fix and now passes.

### Related issues
Closes #262

### Additional information
- Time spent: ~3 hours

### Licensing Certification
FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.