### PR TITLE
H12 Lam Pham - Aaron Shin

### DIFF
--- a/components/CropSelector/CropSelector.content.comp.cy.js
+++ b/components/CropSelector/CropSelector.content.comp.cy.js
@@ -108,4 +108,14 @@ describe('Test the CropSelector content', () => {
       .should('be.visible')
       .should('be.enabled');
   });
+
+  it('Check that allowCreate prop handles visibility of crop plus button', () => {
+    cy.mount(CropSelector, {
+      props: {
+        allowCreate: false,
+      },
+    });
+
+    cy.get('[data-cy="selector-add-button"]').should('not.exist');
+  });
 });

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -105,6 +105,9 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * Whether to allow creating new crops via the "+" button.
+     */
     allowCreate: {
       type: Boolean,
       default: true,
@@ -173,7 +176,7 @@ export default {
         if (this.canCreateCrop && this.allowCreate) {
           this.popupUrl = '/admin/structure/taxonomy/manage/plant_type/add';
         } else {
-          this.popUrl = null;
+          this.popupUrl = null;
         }
 
         /**

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -175,10 +175,7 @@ export default {
 
         if (this.canCreateCrop && this.allowCreate) {
           this.popupUrl = '/admin/structure/taxonomy/manage/plant_type/add';
-        } else {
-          this.popupUrl = null;
         }
-
         /**
          * The select has been populated with the list of crops and the component is ready to be used.
          */

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -105,6 +105,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    allowCreate: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -166,8 +170,10 @@ export default {
         this.cropList = Array.from(cropMap.keys());
         this.canCreateCrop = canCreate;
 
-        if (this.canCreateCrop) {
+        if (this.canCreateCrop && this.allowCreate) {
           this.popupUrl = '/admin/structure/taxonomy/manage/plant_type/add';
+        } else {
+          this.popUrl = null;
         }
 
         /**

--- a/modules/farm_fd2/src/entrypoints/harvest/App.vue
+++ b/modules/farm_fd2/src/entrypoints/harvest/App.vue
@@ -23,6 +23,7 @@
       data-cy="harvest-crop"
       v-bind:required="true"
       v-bind:showValidityStyling="true"
+      v-bind:allowCreate="false"
       v-model:selected="crop"
       v-on:error="(msg) => showErrorToast('Network Error', msg)"
     />


### PR DESCRIPTION
### Purpose
The `CropSelector` component used in the Harvest form previously included a "+" button that allowed users to add new crop types. This behavior is inconsistent with the workflow, as a crop must exist and be planted before it can be harvested.

This PR removes that "+" button to prevent the creation of new crops during the harvest process.

### Verification steps
Follow these steps manually to confirm that the fix behaves correctly:

1. Open the **Harvest** form (FarmData2 -> Harvest).
2. Locate the "Crop" dropdown selector.
3. Verify that the **green "+" button is NOT present** on the right edge of the input.
4. Navigate to the **Seeding** form ( or any other from using CropSelector component).
5. Locate the "Crop" dropdown selector.
6. Verify that the "+" button is visible and functional (assuming the user has permission).

### Approach
* **Updated `CropSelector` Component:** Added a new prop called `allowCreate` which defaults to `true` to maintain existing behavior in other forms.
* **Logic Change:** Updated the component's creation logic to check both the user's existing permissions (`canCreate`) and this new `allowCreate` prop before setting the `popupUrl`.
* **UI Behavior:** If `allowCreate` is `false`, `popupUrl` remains `null`, which signals the underlying `SelectorBase` to hide the "+" add button.
* **Implementation:** For the Harvest form in the `modules/farm_fd2/src/entrypoints/harvest/App.vue`, passed `v-bind:allowCreate="false"` to the `CropSelector` to explicitly disable crop creation in this specific workflow.

### Testing
We added a new Cypress component test named `Check that allowCreate prop handles visibility of crop plus button`. This test mounts the `CropSelector` component with the `allowCreate` prop set to false and verifies that the "+" button is correctly hidden.

### Related issues
Closes #279

### Additional information
Time spent: ~1 hour

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.