### PR TITLE
Fixed harvest form not resetting

### DIFF
--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -201,6 +201,11 @@ export default {
   watch: {
     async crop() {
       if (this.crop) {
+        this.pickedPlant = null;
+        this.quantity = 1;
+        this.unit = null;
+        this.comment = '';
+
         this.plantList = await farmosUtil.getPlantAssets(
           null,
           [],

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -77,4 +77,36 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+  it('Should reset the form when the crop is changed', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('RADISH');
+
+    cy.get('[data-cy="harvest-table"]')
+      .find('input[type="radio"]')
+      .first()
+      .check();
+
+    cy.get('[data-cy="harvest-comment"]')
+      .find('[data-cy="comment-input"]')
+      .type('Old Comment');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+
+    cy.get('[data-cy="harvest-comment"]')
+      .find('[data-cy="comment-input"]')
+      .should('have.value', '');
+  });
 });


### PR DESCRIPTION
### Purpose
Fixed a bug in the Harvest form where user-entered data (such as the selected plant, quantity, and unit) persisted incorrectly when the user switched from one crop to another. This change ensures that the form resets to a clean state whenever the crop selection changes, preventing the submission of invalid or mismatched data.

### Verification steps
1. Log in to farmOS as manager1 and navigate to the OSS1 page

2. Select a crop that has harvestable plants

3. Select a specific plant from the table and type something in the comment box

4. Verify that the "Submit" button is enabled

5. Change the "Crop" selection to a different crop

6. Verify: The "Submit" button should immediately become disabled

7. Verify: The "Comment" box should be empty
### Approach
The bug was caused because the Vue component maintained the state of the form fields (pickedPlant, quantity, unit, and comment) even after the crop data property changed. I addressed this by modifying the watch handler for the crop property.

### Testing
Should reset the form when the crop is changed: This test simulates the user workflow of selecting a crop, filling out the form, and then switching to a different crop. It asserts that the form correctly resets by verifying that the "Submit" button becomes disabled and the comment field becomes empty.

### Related issues
Closes #300 

### Additional information
Finished this assignment in 3 hours

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
