### PR TITLE
Fixed the bug found in Harvest Form validation logic

### DIFF
--- a/modules/farm_fd2_school/src/entrypoints/FD4_Application/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/FD4_Application/App.vue
@@ -3,10 +3,11 @@
     id="FD3"
     data-cy="FD3"
   >
-    <div id="harvest-header"><h1>Harvest</h1></div>
+    <div data-cy="harvest-header"><h1>Harvest</h1></div>
 
     <DateSelector
       id="harvest-date"
+      data-cy="date-selector"
       v-bind:required="true"
       v-bind:showValidityStyling="true"
       v-model:date="date"
@@ -14,6 +15,7 @@
 
     <CropSelector
       id="harvest-crop"
+      data-cy="crop-selector"
       v-bind:required="true"
       v-bind:showValidityStyling="true"
       v-model:selected="crop"
@@ -26,7 +28,10 @@
       id="harvest-table-quantity-unit"
       v-if="plantList.length > 0"
     >
-      <table id="harvest-table">
+      <table
+        id="harvest-table"
+        data-cy="plant-table"
+      >
         <tr id="harvest-table-header">
           <th></th>
           <th>Location</th>
@@ -57,11 +62,13 @@
         v-bind:incDecValues="[1, 5]"
         v-bind:minValue="1"
         v-model:value="quantity"
+        data-cy="quantity-input"
       />
       <select
         id="harvest-units"
         v-model="unit"
         v-if="this.unitList.length > 1"
+        data-cy="units-select"
       >
         <option
           v-for="unit in unitList"
@@ -77,6 +84,7 @@
       <CommentBox
         id="harvest-comment"
         v-model:comment="comment"
+        data-cy="comment-box"
       />
     </div>
     <div
@@ -91,6 +99,7 @@
       v-bind:enableReset="true"
       v-on:submit="submitForm"
       v-on:reset="resetForm"
+      data-cy="submit"
     />
 
     <hr />

--- a/modules/farm_fd2_school/src/entrypoints/FD4_Application/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/FD4_Application/harvest.e2e.cy.js
@@ -11,8 +11,25 @@ describe('Tests for the Harvest form', () => {
     cy.saveLocalStorage();
     cy.saveSessionStorage();
   });
+  it('Test initial state of the Harvest form', () => {
+    cy.get('[data-cy="harvest-header"]')
+      .should('be.visible')
+      .and('contain', 'Harvest');
 
-  it('Placeholder test', () => {
-    cy.get('[data-cy="does-not-exist"]');
+    cy.get('[data-cy="date-selector"]')
+      .should('be.visible')
+      .find('input')
+      .should('have.value', '2019-06-15');
+
+    cy.get('[data-cy="crop-selector"]')
+      .should('be.visible')
+      .find('select')
+      .should('have.value', null);
+    cy.get('[data-cy="submit"]').should('be.visible').and('be.disabled'); 
+
+    cy.get('[data-cy="plant-table"]').should('not.exist');
+    cy.get('[data-cy="quantity-input"]').should('not.exist');
+    cy.get('[data-cy="units-select"]').should('not.exist');
+    cy.get('[data-cy="comment-box"]').should('not.exist');
   });
 });

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/App.vue
@@ -201,6 +201,10 @@ export default {
   watch: {
     async crop() {
       if (this.crop) {
+        this.pickedPlant = null;
+        this.quantity = 1;
+        this.unit = null;
+        this.comment = '';
         this.plantList = await farmosUtil.getPlantAssets(
           null,
           [],

--- a/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
+++ b/modules/farm_fd2_school/src/entrypoints/OSS1/harvest.e2e.cy.js
@@ -68,7 +68,7 @@ describe('Tests for the Harvest form', () => {
       .should('be.visible')
       .should(
         'contain.text',
-        'There are no CARROT plants available for harvest.'
+        'There are no ASPARAGUS plants available for harvest.'
       );
 
     cy.get('[data-cy="harvest-table"]').should('not.exist');
@@ -76,5 +76,37 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="harvest-units"]').should('not.exist');
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
+  });
+  it('Should reset the form when the crop is changed', () => {
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('BEAN');
+
+    cy.get('[data-cy="harvest-table"]')
+      .find('input[type="radio"]')
+      .first()
+      .check();
+
+    cy.get('[data-cy="harvest-comment"]')
+      .find('[data-cy="comment-input"]')
+      .type('Old Comment');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('be.enabled');
+
+    cy.get('[data-cy="harvest-crop"]')
+      .find('[data-cy="crop-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('ASPARAGUS');
+
+    cy.get('[data-cy="harvest-submit-reset"]')
+      .find('[data-cy="submit-button"]')
+      .should('not.be.enabled');
+
+    cy.get('[data-cy="harvest-comment"]')
+      .find('[data-cy="comment-input"]')
+      .should('have.value', '');
   });
 });

--- a/modules/farm_fd2_school/src/entrypoints/Vue1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/Vue1/App.vue
@@ -71,9 +71,13 @@
       class="label-margin"
     />
     <select id="harvest-units">
-      <option selected>BUNCH</option>
-      <option>EACH</option>
-      <option>POUND</option>
+      <option
+        v-for="unit in units"
+        v-bind:key="unit"
+        v-bind:value="unit"
+      >
+        {{ unit }}
+      </option>
     </select>
 
     <hr />
@@ -112,6 +116,7 @@ export default {
         { id: 3, date: '02/04/2019', location: 'GHANA', bed: 'GHANA-4' },
         { id: 4, date: '06/05/2019', location: 'E', bed: '' },
       ],
+      units: ['BUNCH', 'EACH', 'POUND'],
     };
   },
 };

--- a/modules/farm_fd2_school/src/entrypoints/Vue1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/Vue1/App.vue
@@ -26,7 +26,7 @@
       <option
         v-for="crop in crops"
         v-bind:key="crop"
-        v-bind:value="cro"
+        v-bind:value="crop"
       >
         {{ crop }}
       </option>
@@ -41,57 +41,19 @@
         <th>Bed</th>
         <th>Planted Date</th>
       </tr>
-      <tr>
+      <tr
+        v-for="plant in plants"
+        v-bind:key="plant.id"
+      >
         <td>
           <input
             type="radio"
             name="harvest-plant"
-            id="harvest-plant1"
-            value="1"
           />
         </td>
-        <td>D</td>
-        <td></td>
-        <td>04/02/2019</td>
-      </tr>
-      <tr>
-        <td>
-          <input
-            type="radio"
-            name="harvest-plant"
-            id="harvest-plant2"
-            value="2"
-          />
-        </td>
-        <td>GHANA</td>
-        <td>GHANA-2</td>
-        <td>02/04/2019</td>
-      </tr>
-      <tr>
-        <td>
-          <input
-            type="radio"
-            name="harvest-plant"
-            id="harvest-plant3"
-            value="3"
-          />
-        </td>
-        <td>GHANA</td>
-        <td>GHANA-4</td>
-        <td>02/04/2019</td>
-      </tr>
-      <tr>
-        <td>
-          <input
-            type="radio"
-            name="harvest-plant"
-            id="harvest-plant4"
-            value="4"
-          />
-        </td>
-        <td>E</td>
-        <td></td>
-        <td>06/05/2019</td>
+        <td>{{ plant.location }}</td>
+        <td>{{ plant.bed }}</td>
+        <td>{{ plant.date }}</td>
       </tr>
     </table>
 
@@ -144,6 +106,12 @@ export default {
   data() {
     return {
       crops: ['Arugula', 'Asparagus', 'Bean', 'Radish'],
+      plants: [
+        { id: 1, date: '04/02/2019', location: 'D', bed: '' },
+        { id: 2, date: '02/04/2019', location: 'GHANA', bed: 'GHANA-2' },
+        { id: 3, date: '02/04/2019', location: 'GHANA', bed: 'GHANA-4' },
+        { id: 4, date: '06/05/2019', location: 'E', bed: '' },
+      ],
     };
   },
 };

--- a/modules/farm_fd2_school/src/entrypoints/Vue1/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/Vue1/App.vue
@@ -23,10 +23,13 @@
       Crop:
     </label>
     <select id="harvest-crop">
-      <option>ARUGULA</option>
-      <option>ASPARAGUS</option>
-      <option>BEAN</option>
-      <option selected>RADISH</option>
+      <option
+        v-for="crop in crops"
+        v-bind:key="crop"
+        v-bind:value="cro"
+      >
+        {{ crop }}
+      </option>
     </select>
 
     <hr />
@@ -136,7 +139,15 @@
   </div>
 </template>
 
-<script></script>
+<script>
+export default {
+  data() {
+    return {
+      crops: ['Arugula', 'Asparagus', 'Bean', 'Radish'],
+    };
+  },
+};
+</script>
 
 <style>
 /* import some styling that applies to all FD2 entry points */

--- a/modules/farm_fd2_school/src/entrypoints/Vue2/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/Vue2/App.vue
@@ -44,13 +44,15 @@
         <th>Planted Date</th>
       </tr>
       <tr
-        v-for="plant in plantList"
+        v-for="(plant, index) in plantList"
         v-bind:key="plant.id"
       >
         <td>
           <input
             type="radio"
             name="harvest-plant"
+            v-model="selectedPlantIndex"
+            v-bind:value="index"
           />
         </td>
         <td>{{ plant.location }}</td>
@@ -127,6 +129,7 @@ export default {
       quantity: 1,
       selectedUnit: 'BUNCH',
       comment: '',
+      selectedPlantIndex: -1,
     };
   },
 };

--- a/modules/farm_fd2_school/src/entrypoints/Vue2/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/Vue2/App.vue
@@ -13,7 +13,7 @@
     <input
       type="date"
       id="harvest-date"
-      value="2019-06-15"
+      v-model="date"
     />
     <br />
     <label
@@ -22,7 +22,10 @@
     >
       Crop:
     </label>
-    <select id="harvest-crop">
+    <select
+      id="harvest-crop"
+      v-model="selectedCrop"
+    >
       <option
         v-for="crop in cropList"
         v-bind:key="crop"
@@ -64,12 +67,15 @@
     <input
       type="number"
       id="harvest-quantity"
-      value="1"
+      v-model.number="quantity"
       min="1"
       size="7"
       class="label-margin"
     />
-    <select id="harvest-units">
+    <select
+      id="harvest-units"
+      v-model="selectedUnit"
+    >
       <option
         v-for="unit in unitList"
         v-bind:key="unit.id"
@@ -85,6 +91,7 @@
       rows="5"
       cols="35"
       placeholder="Enter a comment..."
+      v-model="comment"
     />
     <br />
     <input
@@ -115,6 +122,11 @@ export default {
         { id: 4, date: '06/05/2019', location: 'GHANA', bed: 'GHANA-4' },
       ],
       unitList: ['BUNCH', 'EACH', 'POUND'],
+      date: '2019-06-15',
+      selectedCrop: 'RADISH',
+      quantity: 1,
+      selectedUnit: 'BUNCH',
+      comment: '',
     };
   },
 };

--- a/modules/farm_fd2_school/src/entrypoints/Vue2/App.vue
+++ b/modules/farm_fd2_school/src/entrypoints/Vue2/App.vue
@@ -101,11 +101,13 @@
       id="harvest-submit"
       value="Submit"
       class="label-margin"
+      v-on:click="console.log('submit was clicked!')"
     />
     <input
       type="button"
       id="harvest-reset"
       value="Reset"
+      v-on:click="console.log('Reset was clicked')"
     />
 
     <hr />


### PR DESCRIPTION
### Purpose
This PR fixes an issue in the Harvest form where old data (like the selected plant, quantity, and comments) would stay visible even after switching to a different crop. Now, the form correctly clears out all those fields whenever a new crop is selected, so users don't accidentally submit the wrong info.
### Verification steps
_A clear and concise set of steps that will enable the reviewer to manually verify that this pull request accomplishes its purpose._

### Approach
1. Log in as manager1 and go to OSS1 page
2. Pick a crop that has a plant (BEAN)
3. Select a plant radio button and type something in the "Comment" box
4. Notice that the "Submit" button becomes enabled
5. Now, switch the "Crop" dropdown to a different one (ARUGULA)
6. Verify: The "Submit" button should immediately disable
7. Verify: The "Comment" box should go back to being empty.

### Testing
Run the Cypress tests and make sure the new test Should reset the form when the crop is changed passes

### Related issues
Closes #306 

### Additional information
_Include any additional information you think might be helpful here._

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
