### PR TITLE
Add allowAdd prop to CropSelector to disable "+" button on Harvest form

### DIFF
--- a/components/CropSelector/CropSelector.content.comp.cy.js
+++ b/components/CropSelector/CropSelector.content.comp.cy.js
@@ -108,4 +108,17 @@ describe('Test the CropSelector content', () => {
       .should('be.visible')
       .should('be.enabled');
   });
+
+  it('Crop plus button does not exist', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(CropSelector, {
+      props: {
+        onReady: readySpy,
+        allowAdd: false,
+      },
+    });
+
+    cy.get('[data-cy="selector-add-button"]').should('not.exist');
+  });
 });

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -106,7 +106,7 @@ export default {
       default: false,
     },
     /**
-     * Whether the "+" should appear on the crop dropdown menu.
+     * Whether the user is allowed to add a new crop or not.
      */
     allowAdd: {
       type: Boolean,

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -105,6 +105,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    allowAdd: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -166,7 +170,7 @@ export default {
         this.cropList = Array.from(cropMap.keys());
         this.canCreateCrop = canCreate;
 
-        if (this.canCreateCrop) {
+        if (this.canCreateCrop && this.allowAdd) {
           this.popupUrl = '/admin/structure/taxonomy/manage/plant_type/add';
         }
 

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -105,6 +105,9 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * Whether the "+" should appear on the crop dropdown menu.
+     */
     allowAdd: {
       type: Boolean,
       default: true,

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -173,7 +173,6 @@ export default {
         if (this.canCreateCrop && this.allowAdd) {
           this.popupUrl = '/admin/structure/taxonomy/manage/plant_type/add';
         }
-
         /**
          * The select has been populated with the list of crops and the component is ready to be used.
          */

--- a/modules/farm_fd2/src/entrypoints/harvest/App.vue
+++ b/modules/farm_fd2/src/entrypoints/harvest/App.vue
@@ -25,6 +25,7 @@
       v-bind:showValidityStyling="true"
       v-model:selected="crop"
       v-on:error="(msg) => showErrorToast('Network Error', msg)"
+      v-bind:allowAdd="false"
     />
 
     <hr />

--- a/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
@@ -4,7 +4,7 @@ describe('Tests for the Harvest form', () => {
     cy.restoreSessionStorage();
 
     cy.login('manager1', 'farmdata2');
-    cy.visit('fd2_school/OSS1');
+    cy.visit('fd2/harvest');
   });
 
   afterEach(() => {

--- a/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
@@ -77,4 +77,7 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
   });
+  it('Crop plus button does not exist', () => {
+    cy.get('[data-cy="selector-add-button"]').should('not.exist');
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/harvest/harvest.e2e.cy.js
@@ -35,6 +35,8 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="harvest-units"]').should(`not.exist`);
     cy.get('[data-cy="single-harvest-unit"]').should(`not.exist`);
     cy.get('[data-cy="harvest-comment"]').should(`not.exist`);
+
+    cy.get('[data-cy="selector-add-button"]').should('not.exist');
   });
 
   it('Selecting crop with harvestable plants', () => {
@@ -76,8 +78,5 @@ describe('Tests for the Harvest form', () => {
     cy.get('[data-cy="harvest-units"]').should('not.exist');
     cy.get('[data-cy="single-harvest-unit"]').should('not.exist');
     cy.get('[data-cy="harvest-comment"]').should('not.exist');
-  });
-  it('Crop plus button does not exist', () => {
-    cy.get('[data-cy="selector-add-button"]').should('not.exist');
   });
 });


### PR DESCRIPTION
### Purpose
This pull request updates the CropSelector component so that the green “+” button for adding a new crop can be optionally disabled.
In particular, the Harvest form should not allow adding a new crop from the CropSelector, since a crop must already exist in order to be harvested. This PR adds a prop to CropSelector to control that behavior and sets it so that the “+” is hidden on the Harvest form while remaining available in other contexts.

### Verification steps
Navigate to: FarmData2 → Harvest. Locate the Crop input on the Harvest form.
Confirm that:
- There is no green “+” button on the right side of the Crop selector.
- You can still select an existing crop and submit the form as usual.

### Approach

1. A new optional prop named allowAdd was introduced to the CropSelector component. This prop determines whether the "+" button for creating a new crop should appear. The default behavior remains unchanged, since allowAdd defaults to true, meaning all existing forms continue to show the button unless they explicitly choose not to.
2. Inside the component, the logic that enables the "+" button was updated so that it only activates when two conditions are met: the user has permission to create new crop types, and allowAdd is set to true. If either condition is not met, the button is not shown.
3. On the Harvest form, allowAdd is now set to false. This removes the "+" button from that specific form, reflecting the fact that new crops should not be added during a harvest operation. All other forms that rely on the existing behavior continue to function normally.

### Testing
- Manual testing: Verified that the Harvest form no longer shows the green “+” button next to the Crop selector.
- Automated testing: Ran:
`test.bash --fd2 --live --e2e --glob=modules/farm_fd2/**/harvest/*.e2e.cy.js --gui`
All existing Harvest E2E tests passed.

### Related issues
Close #279

### Additional Information
H12 - OSS2 Submission. Gracie and Rohan

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
